### PR TITLE
Fix python version 3.7 with architecture x64 not found for Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       NOTION_TOKEN: 'mock_notion_token'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         pip install requests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
       DATABASE_PARENT_ID: 'mock_database_parent_id'
       NOTION_TOKEN: 'mock_notion_token'
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         pip install requests

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Python
       uses: "actions/setup-python@v4"
       with:
-          python-version: "3.10"
+          python-version: "3.12"
     - name: Install dbt
       run: "pip3 install ${{ inputs.dbt-package }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Python
       uses: "actions/setup-python@v4"
       with:
-          python-version: "3.7"
+          python-version: "3.10"
     - name: Install dbt
       run: "pip3 install ${{ inputs.dbt-package }}"
       shell: bash


### PR DESCRIPTION
Hello @rfdearborn, 
First of all, thanks for the awesome work you and your collaborators have done with this GitHub Action.

This PR addresses #26.
The issue is straight forward: Python 3.7 is not any more part of the GitHub runner image tagged as `ubuntu-latest` (see the [image manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)). In fact, is not part of any of the available Ubuntu-base runner images anymore.

I bumped the Python version to 3.12, alongside versions of pre-required GitHub actions. I chose 3.12 as is the latest version for dbt supports (see [compatibility matrix](https://docs.getdbt.com/faqs/Core/install-python-compatibility#python-compatibility-matrix)). This should cover dbt v1.7+ and dbt v1,8+, including the latest data unittest features.

I have verified that
1. Changes I made do not break the project's tests (see [workflow run details](https://github.com/slothkong/dbt-docs-to-notion/actions/runs/13259274548/job/37011974394))
2. The GitHub action runs end-to-end, using my own dbt project with a CI pipeline using [slothkong/dbt-docs-to-notion@main](https://github.com/slothkong/dbt-docs-to-notion), and my own Notion instance (see [1] and [2])


Let me know if there is anything else I can do to make it easier for the fix to get merged~


[1]  Logs of dbt project's CI pipeline
<img width="625" alt="image" src="https://github.com/user-attachments/assets/a2966dcf-7b8f-420c-87c0-fe31b89aaba5" />

[2] Output in Notion
<img width="638" alt="image" src="https://github.com/user-attachments/assets/c38f8025-b125-4df1-8a59-b69c58c5066d" />
