### PR TITLE
feat(dbt-docs): Handle variable length Rich text within notion 2k token limit

### DIFF
--- a/dbt_docs_to_notion.py
+++ b/dbt_docs_to_notion.py
@@ -58,25 +58,14 @@ def get_owner(data, catalog_nodes, model_name):
   return get_paths_or_empty(catalog_nodes, [[model_name, 'metadata', 'owner']], '')
 
 
-  def variable_rich_text_length(data):
-      """
-      Check length of Rich text block and format into =<2000 character sections
-      """
-      data_parts_list = []
-      if len(data) <= 2000:
-          data_part = {
-              "type": "text",
-              "text": {"content": data[:2000]},
-          }
-          data_parts_list.append(data_part)
-      else:
-          for n in range(0, len(data), 2000):
-              data_part = {
-                  "type": "text",
-                  "text": {"content": data[n : n + 2000]},
-              }
-              data_parts_list.append(data_part)
-      return data_parts_list
+def variable_rich_text_length(data):
+    """
+    Check length of Rich text block and format into =<2000 character sections
+    """
+    return [
+            {"type": "text", "text": {"content": data[n:n+2000]}}
+            for n in range(0, len(data), 2000)
+    ]
 
 
 def main(argv=None):
@@ -359,7 +348,7 @@ def main(argv=None):
           "object": "block",
           "type": "code",
           "code": {
-            "rich_text": variable_rich_text_length(data["raw_code"]),
+            "rich_text": variable_rich_text_length(data.get("raw_code") or data.get("raw_sql", "")),
             "language": "sql"
           }
         },
@@ -380,7 +369,7 @@ def main(argv=None):
           "object": "block",
           "type": "code",
           "code": {
-            "rich_text": variable_rich_text_length(data["compiled_code"]),
+            "rich_text": variable_rich_text_length(data.get("compiled_code") or data.get("compiled_sql", "")),
             "language": "sql"
           }
         }

--- a/dbt_docs_to_notion.py
+++ b/dbt_docs_to_notion.py
@@ -58,6 +58,27 @@ def get_owner(data, catalog_nodes, model_name):
   return get_paths_or_empty(catalog_nodes, [[model_name, 'metadata', 'owner']], '')
 
 
+  def variable_rich_text_length(data):
+      """
+      Check length of Rich text block and format into =<2000 character sections
+      """
+      data_parts_list = []
+      if len(data) <= 2000:
+          data_part = {
+              "type": "text",
+              "text": {"content": data[:2000]},
+          }
+          data_parts_list.append(data_part)
+      else:
+          for n in range(0, len(data), 2000):
+              data_part = {
+                  "type": "text",
+                  "text": {"content": data[n : n + 2000]},
+              }
+              data_parts_list.append(data_part)
+      return data_parts_list
+
+
 def main(argv=None):
   if argv is None:
     argv = sys.argv
@@ -338,14 +359,7 @@ def main(argv=None):
           "object": "block",
           "type": "code",
           "code": {
-            "rich_text": [
-              {
-                "type": "text",
-                "text": {
-                  "content": data['raw_code'][:2000] if 'raw_code' in data else data['raw_sql'][:2000]
-                }
-              }
-            ],
+            "rich_text": variable_rich_text_length(data["raw_code"]),
             "language": "sql"
           }
         },
@@ -366,14 +380,7 @@ def main(argv=None):
           "object": "block",
           "type": "code",
           "code": {
-            "rich_text": [
-              {
-                "type": "text",
-                "text": {
-                  "content": data['compiled_code'][:2000] if 'compiled_code' in data else data['compiled_sql'][:2000]
-                }
-              }
-            ],
+            "rich_text": variable_rich_text_length(data["compiled_code"]),
             "language": "sql"
           }
         }


### PR DESCRIPTION
This PR add variable length (>2000) for any rich_text code field! Technically this can also be used for very long descriptions but current implementation is only for `raw_code` & `compiled_code`